### PR TITLE
Fix the name of the "Basic sentences" chapter in the config

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -35,7 +35,7 @@ export default defineUserConfig({
           children: [
             'README.md',
             'pronunciation.md',
-            'basic-grammar.md',   
+            'basic-sentences.md',   
             'complex-sentences.md',
             // add more chapters later
           ],


### PR DESCRIPTION
This commit should fix invalid links to the next and previous chapter in adjacent chapters, and also add the links ta the next and previous chapter on the "Basic sentences" page