### PR TITLE
questions-clauses.md typo fix "ke" -> "le"

### DIFF
--- a/docs/guide/questions-clauses.md
+++ b/docs/guide/questions-clauses.md
@@ -164,10 +164,10 @@ Clauses can be closed in multiple ways, sometimes stacking multiple closers to a
 
 | Kokanu phrase (variants)                                               | Meaning                                  |
 |------------------------------------------------------------------------|------------------------------------------|
-| **nenka ta tu le cuma hon ta mi le koman, mi ke kujo**                  | I am sad because you leave when I come   |
-| **nenka ta tu le cuma hon ta mi le koman,, mi ke kujo**             | (same, but multiple , used)        |
-| **nenka ta tu le cuma hon ta mi le koman hu, mi ke kujo**             | (same, but hu used)        |
-| **nenka ta tu le cuma hon ta mi le koman hu hu mi ke kujo**             | (same, but multiple hu used)        |
+| **nenka ta tu le cuma hon ta mi le koman, mi le kujo**                  | I am sad because you leave when I come   |
+| **nenka ta tu le cuma hon ta mi le koman,, mi le kujo**             | (same, but multiple , used)        |
+| **nenka ta tu le cuma hon ta mi le koman hu, mi le kujo**             | (same, but hu used)        |
+| **nenka ta tu le cuma hon ta mi le koman hu hu mi le kujo**             | (same, but multiple hu used)        |
 
 ---
 


### PR DESCRIPTION
Under the Nested Clauses section of the "ta" section, I changed 4 occurrences of "mi ke kujo" to "mi le kujo," in suspicion of a copypasted typo.